### PR TITLE
Don't archive the jar, since it's a zip anyway

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
         run: echo "sha_short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Intave-${{ steps.vars.outputs.sha_short }}.jar
           path: build/libs/Intave.jar
+          archive: false
           retention-days: 7
-          compression-level: 0
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Upload action allows not to archive single files and since Jar is just a zip the compression is unnecessary 