### PR TITLE
Add block dig validation check

### DIFF
--- a/src/main/java/de/jpx3/intave/check/other/ProtocolScanner.java
+++ b/src/main/java/de/jpx3/intave/check/other/ProtocolScanner.java
@@ -2,6 +2,7 @@ package de.jpx3.intave.check.other;
 
 import de.jpx3.intave.IntavePlugin;
 import de.jpx3.intave.check.Check;
+import de.jpx3.intave.check.other.protocolscanner.InvalidDig;
 import de.jpx3.intave.check.other.protocolscanner.InvalidPitch;
 import de.jpx3.intave.check.other.protocolscanner.SentSlotTwice;
 import de.jpx3.intave.check.other.protocolscanner.SkinBlinker;
@@ -14,9 +15,10 @@ public final class ProtocolScanner extends Check {
     this.plugin = plugin;
 
     appendCheckParts(
-      new SentSlotTwice(this),
-      new InvalidPitch(this),
-      new SkinBlinker(this)
+            new SentSlotTwice(this),
+            new InvalidPitch(this),
+            new InvalidDig(this),
+            new SkinBlinker(this)
     );
   }
 }

--- a/src/main/java/de/jpx3/intave/check/other/protocolscanner/InvalidDig.java
+++ b/src/main/java/de/jpx3/intave/check/other/protocolscanner/InvalidDig.java
@@ -1,0 +1,53 @@
+package de.jpx3.intave.check.other.protocolscanner;
+
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.BlockPosition;
+import com.comphenix.protocol.wrappers.EnumWrappers;
+import de.jpx3.intave.adapter.MinecraftVersions;
+import de.jpx3.intave.check.CheckPart;
+import de.jpx3.intave.check.other.ProtocolScanner;
+import de.jpx3.intave.module.Modules;
+import de.jpx3.intave.module.linker.packet.PacketId;
+import de.jpx3.intave.module.linker.packet.PacketSubscription;
+import de.jpx3.intave.module.violation.Violation;
+import org.bukkit.entity.Player;
+
+public final class InvalidDig extends CheckPart<ProtocolScanner> {
+    public InvalidDig(ProtocolScanner parentCheck) {
+        super(parentCheck);
+    }
+
+    @PacketSubscription(
+            packetsIn = {
+                    PacketId.Client.BLOCK_DIG
+            }
+    )
+    public void receiveBlockDig(PacketEvent event) {
+        PacketContainer packet = event.getPacket();
+        Player player = event.getPlayer();
+        EnumWrappers.PlayerDigType digType = packet.getPlayerDigTypes().readSafely(0);
+        BlockPosition blockPosition = packet.getBlockPositionModifier().readSafely(0);
+
+        if (digType != EnumWrappers.PlayerDigType.START_DESTROY_BLOCK
+                && digType != EnumWrappers.PlayerDigType.ABORT_DESTROY_BLOCK
+                && digType != EnumWrappers.PlayerDigType.STOP_DESTROY_BLOCK
+        ) {
+
+            final int expectedFace = !MinecraftVersions.VER1_8_0.atOrAbove() && digType == EnumWrappers.PlayerDigType.RELEASE_USE_ITEM ? 255 : 0;
+
+            if (packet.getDirections().size() != expectedFace
+                    || blockPosition.getX() != 0
+                    || blockPosition.getY() != 0
+                    || blockPosition.getZ() != 0
+                    || packet.getIntegers().read(0) != 0
+            ) {
+                Violation violation = Violation.builderFor(ProtocolScanner.class)
+                        .forPlayer(player).withMessage("sent invalid digging").withDetails("type " + digType.name().toLowerCase())
+                        .withVL(100)
+                        .build();
+                Modules.violationProcessor().processViolation(violation);
+            }
+        }
+    }
+}

--- a/src/main/java/de/jpx3/intave/check/other/protocolscanner/InvalidDig.java
+++ b/src/main/java/de/jpx3/intave/check/other/protocolscanner/InvalidDig.java
@@ -28,6 +28,8 @@ public final class InvalidDig extends CheckPart<ProtocolScanner> {
         Player player = event.getPlayer();
         EnumWrappers.PlayerDigType digType = packet.getPlayerDigTypes().readSafely(0);
         BlockPosition blockPosition = packet.getBlockPositionModifier().readSafely(0);
+        EnumWrappers.Direction direction = packet.getDirections().readSafely(0);
+        int enumDirection = direction == null ? 0 : direction.ordinal();
 
         if (digType != EnumWrappers.PlayerDigType.START_DESTROY_BLOCK
                 && digType != EnumWrappers.PlayerDigType.ABORT_DESTROY_BLOCK
@@ -36,7 +38,7 @@ public final class InvalidDig extends CheckPart<ProtocolScanner> {
 
             final int expectedFace = !MinecraftVersions.VER1_8_0.atOrAbove() && digType == EnumWrappers.PlayerDigType.RELEASE_USE_ITEM ? 255 : 0;
 
-            if (packet.getDirections().size() != expectedFace
+            if (enumDirection != expectedFace
                     || blockPosition.getX() != 0
                     || blockPosition.getY() != 0
                     || blockPosition.getZ() != 0


### PR DESCRIPTION
Added a check to validate BLOCK_DIG packet information (inspired by GrimAC - BadPacketsL).

The check should work stably, including 1.7.10 (direction 255 by release use item).

This can detect FastBow and detects some bypass NoSlow.

If there are any problems, let me know.
<img width="630" height="431" alt="image" src="https://github.com/user-attachments/assets/173db491-cf4d-418b-9b68-343b10b849a1" />