### PR TITLE
bugfix: read newest data first in AngleSnap rotation loop

### DIFF
--- a/src/main/java/de/jpx3/intave/check/world/placementanalysis/AngleSnap.java
+++ b/src/main/java/de/jpx3/intave/check/world/placementanalysis/AngleSnap.java
@@ -43,8 +43,8 @@ public class AngleSnap extends PlayerCheckPart<PlacementAnalysis> {
       // 5th not included
       float rotationSum = 0;
       int maxHistory = Math.min(5, rotationHistory.size());
-      for (int i = 0; i < rotationHistory.size() - 1; i++) {
-        if (i > maxHistory) {
+      for (int i = rotationHistory.size() - 2; i >= 0; i--) {
+        if (rotationHistory.size() - 1 - i > maxHistory) {
           break;
         }
         rotationSum += Math.abs(rotationHistory.get(i) - rotationHistory.get(i + 1));


### PR DESCRIPTION
## What changed
Changed the `for` loop in the `AngleSnap` check to read `rotationHistory` backwards (starting from the end of the list).

## Why
Since `rotationHistory` is a FIFO queue, index `0` holds the oldest data. The old code was calculating `rotationSum` starting from index `0`, meaning it was actually analyzing old mouse movements instead of the recent ones. 

This fixes it so the check actually looks at the 5 most recent rotations.