### PR TITLE
fix: buffer restart delay in restart check

### DIFF
--- a/src/main/java/de/jpx3/intave/check/world/BreakSpeedLimiter.java
+++ b/src/main/java/de/jpx3/intave/check/world/BreakSpeedLimiter.java
@@ -4,6 +4,7 @@ import de.jpx3.intave.IntavePlugin;
 import de.jpx3.intave.check.Check;
 import de.jpx3.intave.check.CheckViolationLevelDecrementer;
 import de.jpx3.intave.check.world.breakspeedlimiter.CompletionDurationCheck;
+import de.jpx3.intave.check.world.breakspeedlimiter.RestartCheck;
 import de.jpx3.intave.executor.TaskTracker;
 import de.jpx3.intave.user.UserRepository;
 import org.bukkit.Bukkit;
@@ -28,6 +29,6 @@ public final class BreakSpeedLimiter extends Check {
 
   public void setupParts() {
     appendCheckPart(new CompletionDurationCheck(this));
-//    appendCheckPart(new RestartCheck(this));
+    appendCheckPart(new RestartCheck(this));
   }
 }

--- a/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
+++ b/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
@@ -77,10 +77,16 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
             clientData.flyingPacketsAreSent(),
             ticksBetween,
             milliseconds);
-        RestartAssessment assessment = assessRestartDelay(restartDelay, meta.blockBreakStartVL, user.latency());
-        meta.blockBreakStartVL = assessment.balance();
+        double balance = clampBalance(meta.blockBreakStartVL, user.latency());
+        if (restartDelay >= CLOSE_ENOUGH_RESTART_DELAY_MILLIS) {
+          balance *= 0.9D;
+        } else {
+          balance += EXPECTED_RESTART_DELAY_MILLIS - restartDelay;
+        }
+        meta.blockBreakStartVL = balance;
 
-        if (shouldReportRestart(assessment, meta.blockBreakTimestamp, meta.restartFlagBreakTimestamp)) {
+        if (balance > MAX_STORED_RESTART_ADVANTAGE_MILLIS
+            && meta.restartFlagBreakTimestamp != meta.blockBreakTimestamp) {
           String message = "started breaking too quickly";
           String details = restartDelay + "ms between";
           ViolationProcessor violationProcessor = Modules.violationProcessor();
@@ -129,19 +135,6 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
     return breakProcess && targetBlockPosition != null && targetBlockPosition.equals(blockPosition);
   }
 
-  static RestartAssessment assessRestartDelay(
-      long restartDelay,
-      double currentBalance,
-      double balanceLimit) {
-    double balance = clampBalance(currentBalance, balanceLimit);
-    if (restartDelay >= CLOSE_ENOUGH_RESTART_DELAY_MILLIS) {
-      balance *= 0.9D;
-    } else {
-      balance += EXPECTED_RESTART_DELAY_MILLIS - restartDelay;
-    }
-    return new RestartAssessment(balance > MAX_STORED_RESTART_ADVANTAGE_MILLIS, balance, restartDelay);
-  }
-
   static long resolveRestartDelayMillis(
       boolean clientTicksAvailable,
       int ticksBetween,
@@ -149,40 +142,9 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
     return clientTicksAvailable ? ticksBetween * 50L : milliseconds;
   }
 
-  static boolean shouldReportRestart(
-      RestartAssessment assessment,
-      long blockBreakTimestamp,
-      long restartFlagBreakTimestamp) {
-    return assessment.shouldFlag() && restartFlagBreakTimestamp != blockBreakTimestamp;
-  }
-
   private static double clampBalance(double balance, double balanceLimit) {
     double limit = Math.max(MAX_STORED_RESTART_ADVANTAGE_MILLIS, balanceLimit);
     return MathHelper.minmax(-limit, balance, limit);
-  }
-
-  static final class RestartAssessment {
-    private final boolean shouldFlag;
-    private final double balance;
-    private final long delayMillis;
-
-    private RestartAssessment(boolean shouldFlag, double balance, long delayMillis) {
-      this.shouldFlag = shouldFlag;
-      this.balance = balance;
-      this.delayMillis = delayMillis;
-    }
-
-    boolean shouldFlag() {
-      return shouldFlag;
-    }
-
-    double balance() {
-      return balance;
-    }
-
-    long delayMillis() {
-      return delayMillis;
-    }
   }
 
   private void refreshBlocksAround(Player player, Location targetLocation) {

--- a/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
+++ b/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
@@ -21,6 +21,7 @@ import de.jpx3.intave.module.violation.Violation;
 import de.jpx3.intave.module.violation.ViolationContext;
 import de.jpx3.intave.module.violation.ViolationProcessor;
 import de.jpx3.intave.packet.PacketSender;
+import de.jpx3.intave.packet.PacketTypes;
 import de.jpx3.intave.packet.converter.BlockPositionConverter;
 import de.jpx3.intave.user.User;
 import de.jpx3.intave.user.meta.CheckCustomMetadata;
@@ -32,20 +33,29 @@ import org.bukkit.entity.Player;
 import static de.jpx3.intave.module.linker.packet.PacketId.Client.*;
 
 public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, RestartCheck.BreakSpeedStartMeta> {
-  private static final long CLOSE_ENOUGH_RESTART_DELAY_MILLIS = 275L;
-  private static final long EXPECTED_RESTART_DELAY_MILLIS = 300L;
-  private static final double MAX_STORED_RESTART_ADVANTAGE_MILLIS = 1000.0D;
+  private static final double CLOSE_ENOUGH_RESTART_DELAY_TICKS = 5.5D;
+  private static final double EXPECTED_RESTART_DELAY_TICKS = 6.0D;
+  private static final double MAX_STORED_RESTART_ADVANTAGE_TICKS = 20.0D;
 
   public RestartCheck(BreakSpeedLimiter parentCheck) {
     super(parentCheck, RestartCheck.BreakSpeedStartMeta.class);
   }
 
   @PacketSubscription(priority = ListenerPriority.LOWEST, packetsIn = {
-      POSITION, POSITION_LOOK, LOOK, FLYING, VEHICLE_MOVE
+      POSITION, POSITION_LOOK, LOOK, FLYING, VEHICLE_MOVE, CLIENT_TICK_END
   })
   public void tickUpdate(PacketEvent event) {
     Player player = event.getPlayer();
     User user = userOf(player);
+    ProtocolMetadata clientData = user.meta().protocol();
+    boolean clientTickEnd = PacketTypes.isClientEndTick(event.getPacketType());
+    if (clientData.sendsClientTickEnd()) {
+      if (!clientTickEnd) {
+        return;
+      }
+    } else if (!clientData.flyingPacketsAreSent()) {
+      return;
+    }
     BreakSpeedStartMeta meta = metaOf(user);
     meta.ticks++;
   }
@@ -71,24 +81,26 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
           return;
         }
 
-        long milliseconds = System.currentTimeMillis() - meta.blockBreakTimestamp;
+        if (!clientData.flyingPacketsAreSent() && !clientData.sendsClientTickEnd()) {
+          meta.breakProcess = true;
+          meta.targetBlockPosition = blockPosition;
+          break;
+        }
+
         int ticksBetween = meta.ticks - meta.blockBreakTick;
-        long restartDelay = resolveRestartDelayMillis(
-            clientData.flyingPacketsAreSent(),
-            ticksBetween,
-            milliseconds);
-        double balance = clampBalance(meta.blockBreakStartVL, user.latency());
-        if (restartDelay >= CLOSE_ENOUGH_RESTART_DELAY_MILLIS) {
+        double restartDelay = resolveRestartDelayTicks(ticksBetween);
+        double balance = clampBalance(meta.blockBreakStartVL, user.latency() / 50D);
+        if (restartDelay >= CLOSE_ENOUGH_RESTART_DELAY_TICKS) {
           balance *= 0.9D;
         } else {
-          balance += EXPECTED_RESTART_DELAY_MILLIS - restartDelay;
+          balance += EXPECTED_RESTART_DELAY_TICKS - restartDelay;
         }
         meta.blockBreakStartVL = balance;
 
-        if (balance > MAX_STORED_RESTART_ADVANTAGE_MILLIS
-            && meta.restartFlagBreakTimestamp != meta.blockBreakTimestamp) {
+        if (balance > MAX_STORED_RESTART_ADVANTAGE_TICKS
+            && meta.restartFlagBreakSequence != meta.blockBreakSequence) {
           String message = "started breaking too quickly";
-          String details = restartDelay + "ms between";
+          String details = MathHelper.formatDouble(restartDelay, 2) + " ticks between";
           ViolationProcessor violationProcessor = Modules.violationProcessor();
           Violation violation = Violation.builderFor(BreakSpeedLimiter.class)
               .forPlayer(player).withMessage(message).withDetails(details).withVL(5)
@@ -98,7 +110,7 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
             event.setCancelled(true);
             meta.cancelNextStop = true;
           }
-          meta.restartFlagBreakTimestamp = meta.blockBreakTimestamp;
+          meta.restartFlagBreakSequence = meta.blockBreakSequence;
         }
         meta.breakProcess = true;
         meta.targetBlockPosition = blockPosition;
@@ -106,7 +118,7 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
       }
       case STOP_DESTROY_BLOCK: {
         meta.blockBreakTick = meta.ticks;
-        meta.blockBreakTimestamp = System.currentTimeMillis();
+        meta.blockBreakSequence++;
         meta.breakProcess = false;
         meta.targetBlockPosition = null;
         if (meta.cancelNextStop) {
@@ -135,15 +147,12 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
     return breakProcess && targetBlockPosition != null && targetBlockPosition.equals(blockPosition);
   }
 
-  static long resolveRestartDelayMillis(
-      boolean clientTicksAvailable,
-      int ticksBetween,
-      long milliseconds) {
-    return clientTicksAvailable ? ticksBetween * 50L : milliseconds;
+  static double resolveRestartDelayTicks(int ticksBetween) {
+    return Math.max(0, ticksBetween);
   }
 
   private static double clampBalance(double balance, double balanceLimit) {
-    double limit = Math.max(MAX_STORED_RESTART_ADVANTAGE_MILLIS, balanceLimit);
+    double limit = Math.max(MAX_STORED_RESTART_ADVANTAGE_TICKS, balanceLimit);
     return MathHelper.minmax(-limit, balance, limit);
   }
 
@@ -173,10 +182,10 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
     private BlockPosition targetBlockPosition;
     private int ticks;
     private int blockBreakTick;
-    private long blockBreakTimestamp;
+    private long blockBreakSequence;
     private boolean breakProcess;
     private double blockBreakStartVL;
-    private long restartFlagBreakTimestamp = Long.MIN_VALUE;
+    private long restartFlagBreakSequence = Long.MIN_VALUE;
     private boolean cancelNextStop;
   }
 }

--- a/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
+++ b/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
@@ -13,6 +13,7 @@ import de.jpx3.intave.check.MetaCheckPart;
 import de.jpx3.intave.check.world.BreakSpeedLimiter;
 import de.jpx3.intave.executor.Synchronizer;
 import de.jpx3.intave.klass.Lookup;
+import de.jpx3.intave.math.MathHelper;
 import de.jpx3.intave.module.Modules;
 import de.jpx3.intave.module.linker.packet.ListenerPriority;
 import de.jpx3.intave.module.linker.packet.PacketSubscription;
@@ -23,7 +24,6 @@ import de.jpx3.intave.packet.PacketSender;
 import de.jpx3.intave.packet.converter.BlockPositionConverter;
 import de.jpx3.intave.user.User;
 import de.jpx3.intave.user.meta.CheckCustomMetadata;
-import de.jpx3.intave.user.meta.ProtocolMetadata;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -31,92 +31,131 @@ import org.bukkit.entity.Player;
 import static de.jpx3.intave.module.linker.packet.PacketId.Client.*;
 
 public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, RestartCheck.BreakSpeedStartMeta> {
+  private static final long CLOSE_ENOUGH_RESTART_DELAY_MILLIS = 275L;
+  private static final long EXPECTED_RESTART_DELAY_MILLIS = 300L;
+  private static final double MAX_STORED_RESTART_ADVANTAGE_MILLIS = 1000.0D;
+
   public RestartCheck(BreakSpeedLimiter parentCheck) {
     super(parentCheck, RestartCheck.BreakSpeedStartMeta.class);
   }
 
-  @PacketSubscription(
-    priority = ListenerPriority.LOWEST,
-    packetsIn = {
-      POSITION, POSITION_LOOK, LOOK, FLYING, VEHICLE_MOVE
-    }
-  )
-  public void tickUpdate(PacketEvent event) {
-    Player player = event.getPlayer();
-    User user = userOf(player);
-    BreakSpeedStartMeta meta = metaOf(user);
-    meta.ticks++;
-  }
-
-  @PacketSubscription(
-    priority = ListenerPriority.LOWEST,
-    packetsIn = {
+  @PacketSubscription(priority = ListenerPriority.LOWEST, packetsIn = {
       BLOCK_DIG
-    }
-  )
+  })
   public void receiveBlockAction(PacketEvent event) {
     Player player = event.getPlayer();
     User user = userOf(player);
     RestartCheck.BreakSpeedStartMeta meta = metaOf(user);
-    ProtocolMetadata clientData = user.meta().protocol();
 
     PacketContainer packet = event.getPacket();
     EnumWrappers.PlayerDigType digType = packet.getPlayerDigTypes().read(0);
 
     switch (digType) {
       case START_DESTROY_BLOCK: {
-        if (clientData.flyingPacketsAreSent()) {
-          int ticksBetween = meta.ticks - meta.blockBreakTick;
-          if (ticksBetween < 5) {
-            String message = "started breaking too quickly";
-            String details = (ticksBetween == 1 ? "one tick" : ticksBetween + " ticks");
-            ViolationProcessor violationProcessor = Modules.violationProcessor();
-            Violation violation = Violation.builderFor(BreakSpeedLimiter.class)
+        BlockPosition blockPosition = event.getPacket().getModifier()
+            .withType(Lookup.serverClass("BlockPosition"), BlockPositionConverter.threadConverter())
+            .read(0);
+        if (isRepeatedActiveStart(meta.breakProcess, meta.targetBlockPosition, blockPosition)) {
+          return;
+        }
+
+        long milliseconds = System.currentTimeMillis() - meta.blockBreakTimestamp;
+        RestartAssessment assessment = assessRestartDelay(milliseconds, meta.blockBreakStartVL, user.latency());
+        meta.blockBreakStartVL = assessment.balance();
+
+        if (shouldReportRestart(assessment, meta.blockBreakTimestamp, meta.restartFlagBreakTimestamp)) {
+          String message = "started breaking too quickly";
+          String details = milliseconds + "ms between";
+          ViolationProcessor violationProcessor = Modules.violationProcessor();
+          Violation violation = Violation.builderFor(BreakSpeedLimiter.class)
               .forPlayer(player).withMessage(message).withDetails(details).withVL(5)
               .build();
-            ViolationContext violationContext = violationProcessor.processViolation(violation);
-            if (violationContext.shouldCounterThreat()) {
-              event.setCancelled(true);
-              meta.cancelNextStop = true;
-            }
+          ViolationContext violationContext = violationProcessor.processViolation(violation);
+          if (violationContext.shouldCounterThreat()) {
+            event.setCancelled(true);
+            meta.cancelNextStop = true;
           }
-        } else {
-          long milliseconds = System.currentTimeMillis() - meta.blockBreakTimestamp;
-          if (milliseconds < 200) {
-            if (meta.blockBreakStartVL++ > 5) {
-              String message = "started breaking too quickly";
-              String details = milliseconds + "ms between";
-              ViolationProcessor violationProcessor = Modules.violationProcessor();
-              Violation violation = Violation.builderFor(BreakSpeedLimiter.class)
-                .forPlayer(player).withMessage(message).withDetails(details)
-                .withVL(1).build();
-              ViolationContext violationContext = violationProcessor.processViolation(violation);
-              if (violationContext.shouldCounterThreat()) {
-                event.setCancelled(true);
-                meta.cancelNextStop = true;
-              }
-              meta.blockBreakStartVL--;
-            }
-          } else if (meta.blockBreakStartVL > 0) {
-            meta.blockBreakStartVL -= 0.4;
-          }
+          meta.restartFlagBreakTimestamp = meta.blockBreakTimestamp;
         }
+        meta.breakProcess = true;
+        meta.targetBlockPosition = blockPosition;
         break;
       }
       case STOP_DESTROY_BLOCK: {
-        meta.blockBreakTick = meta.ticks;
         meta.blockBreakTimestamp = System.currentTimeMillis();
+        meta.breakProcess = false;
+        meta.targetBlockPosition = null;
         if (meta.cancelNextStop) {
           meta.cancelNextStop = false;
           event.setCancelled(true);
-//          BlockPosition blockPosition = packet.getBlockPositionModifier().read(0);
+          // BlockPosition blockPosition = packet.getBlockPositionModifier().read(0);
           BlockPosition blockPosition = event.getPacket().getModifier()
-            .withType(Lookup.serverClass("BlockPosition"), BlockPositionConverter.threadConverter())
-            .read(0);
+              .withType(Lookup.serverClass("BlockPosition"), BlockPositionConverter.threadConverter())
+              .read(0);
           refreshBlocksAround(player, blockPosition.toLocation(player.getWorld()));
         }
         break;
       }
+      case ABORT_DESTROY_BLOCK:
+        meta.breakProcess = false;
+        meta.targetBlockPosition = null;
+        break;
+    }
+  }
+
+  static boolean isRepeatedActiveStart(
+      boolean breakProcess,
+      BlockPosition targetBlockPosition,
+      BlockPosition blockPosition) {
+    return breakProcess && targetBlockPosition != null && targetBlockPosition.equals(blockPosition);
+  }
+
+  static RestartAssessment assessRestartDelay(
+      long restartDelay,
+      double currentBalance,
+      double balanceLimit) {
+    double balance = clampBalance(currentBalance, balanceLimit);
+    if (restartDelay >= CLOSE_ENOUGH_RESTART_DELAY_MILLIS) {
+      balance *= 0.9D;
+    } else {
+      balance += EXPECTED_RESTART_DELAY_MILLIS - restartDelay;
+    }
+    return new RestartAssessment(balance > MAX_STORED_RESTART_ADVANTAGE_MILLIS, balance, restartDelay);
+  }
+
+  static boolean shouldReportRestart(
+      RestartAssessment assessment,
+      long blockBreakTimestamp,
+      long restartFlagBreakTimestamp) {
+    return assessment.shouldFlag() && restartFlagBreakTimestamp != blockBreakTimestamp;
+  }
+
+  private static double clampBalance(double balance, double balanceLimit) {
+    double limit = Math.max(MAX_STORED_RESTART_ADVANTAGE_MILLIS, balanceLimit);
+    return MathHelper.minmax(-limit, balance, limit);
+  }
+
+  static final class RestartAssessment {
+    private final boolean shouldFlag;
+    private final double balance;
+    private final long delayMillis;
+
+    private RestartAssessment(boolean shouldFlag, double balance, long delayMillis) {
+      this.shouldFlag = shouldFlag;
+      this.balance = balance;
+      this.delayMillis = delayMillis;
+    }
+
+    boolean shouldFlag() {
+      return shouldFlag;
+    }
+
+    double balance() {
+      return balance;
+    }
+
+    long delayMillis() {
+      return delayMillis;
     }
   }
 
@@ -124,10 +163,11 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
     Synchronizer.synchronize(() -> {
       player.updateInventory();
       refreshBlock(player, targetLocation);
-//      for (EnumDirection direction : EnumDirection.values()) {
-//        Location placedBlock = targetLocation.clone().add(direction.getDirectionVec().convertToBukkitVec());
-//        refreshBlock(player, placedBlock);
-//      }
+      // for (EnumDirection direction : EnumDirection.values()) {
+      // Location placedBlock =
+      // targetLocation.clone().add(direction.getDirectionVec().convertToBukkitVec());
+      // refreshBlock(player, placedBlock);
+      // }
     });
   }
 
@@ -147,10 +187,11 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
   }
 
   public static final class BreakSpeedStartMeta extends CheckCustomMetadata {
-    private int ticks;
-    private int blockBreakTick;
+    private BlockPosition targetBlockPosition;
     private long blockBreakTimestamp;
+    private boolean breakProcess;
     private double blockBreakStartVL;
+    private long restartFlagBreakTimestamp = Long.MIN_VALUE;
     private boolean cancelNextStop;
   }
 }

--- a/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
+++ b/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
@@ -24,6 +24,7 @@ import de.jpx3.intave.packet.PacketSender;
 import de.jpx3.intave.packet.converter.BlockPositionConverter;
 import de.jpx3.intave.user.User;
 import de.jpx3.intave.user.meta.CheckCustomMetadata;
+import de.jpx3.intave.user.meta.ProtocolMetadata;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -40,12 +41,23 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
   }
 
   @PacketSubscription(priority = ListenerPriority.LOWEST, packetsIn = {
+      POSITION, POSITION_LOOK, LOOK, FLYING, VEHICLE_MOVE
+  })
+  public void tickUpdate(PacketEvent event) {
+    Player player = event.getPlayer();
+    User user = userOf(player);
+    BreakSpeedStartMeta meta = metaOf(user);
+    meta.ticks++;
+  }
+
+  @PacketSubscription(priority = ListenerPriority.LOWEST, packetsIn = {
       BLOCK_DIG
   })
   public void receiveBlockAction(PacketEvent event) {
     Player player = event.getPlayer();
     User user = userOf(player);
     RestartCheck.BreakSpeedStartMeta meta = metaOf(user);
+    ProtocolMetadata clientData = user.meta().protocol();
 
     PacketContainer packet = event.getPacket();
     EnumWrappers.PlayerDigType digType = packet.getPlayerDigTypes().read(0);
@@ -60,12 +72,17 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
         }
 
         long milliseconds = System.currentTimeMillis() - meta.blockBreakTimestamp;
-        RestartAssessment assessment = assessRestartDelay(milliseconds, meta.blockBreakStartVL, user.latency());
+        int ticksBetween = meta.ticks - meta.blockBreakTick;
+        long restartDelay = resolveRestartDelayMillis(
+            clientData.flyingPacketsAreSent(),
+            ticksBetween,
+            milliseconds);
+        RestartAssessment assessment = assessRestartDelay(restartDelay, meta.blockBreakStartVL, user.latency());
         meta.blockBreakStartVL = assessment.balance();
 
         if (shouldReportRestart(assessment, meta.blockBreakTimestamp, meta.restartFlagBreakTimestamp)) {
           String message = "started breaking too quickly";
-          String details = milliseconds + "ms between";
+          String details = restartDelay + "ms between";
           ViolationProcessor violationProcessor = Modules.violationProcessor();
           Violation violation = Violation.builderFor(BreakSpeedLimiter.class)
               .forPlayer(player).withMessage(message).withDetails(details).withVL(5)
@@ -82,6 +99,7 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
         break;
       }
       case STOP_DESTROY_BLOCK: {
+        meta.blockBreakTick = meta.ticks;
         meta.blockBreakTimestamp = System.currentTimeMillis();
         meta.breakProcess = false;
         meta.targetBlockPosition = null;
@@ -121,6 +139,13 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
       balance += EXPECTED_RESTART_DELAY_MILLIS - restartDelay;
     }
     return new RestartAssessment(balance > MAX_STORED_RESTART_ADVANTAGE_MILLIS, balance, restartDelay);
+  }
+
+  static long resolveRestartDelayMillis(
+      boolean clientTicksAvailable,
+      int ticksBetween,
+      long milliseconds) {
+    return clientTicksAvailable ? ticksBetween * 50L : milliseconds;
   }
 
   static boolean shouldReportRestart(
@@ -188,6 +213,8 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
 
   public static final class BreakSpeedStartMeta extends CheckCustomMetadata {
     private BlockPosition targetBlockPosition;
+    private int ticks;
+    private int blockBreakTick;
     private long blockBreakTimestamp;
     private boolean breakProcess;
     private double blockBreakStartVL;

--- a/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
+++ b/src/main/java/de/jpx3/intave/check/world/breakspeedlimiter/RestartCheck.java
@@ -117,6 +117,7 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
       case ABORT_DESTROY_BLOCK:
         meta.breakProcess = false;
         meta.targetBlockPosition = null;
+        meta.cancelNextStop = false;
         break;
     }
   }
@@ -188,11 +189,6 @@ public final class RestartCheck extends MetaCheckPart<BreakSpeedLimiter, Restart
     Synchronizer.synchronize(() -> {
       player.updateInventory();
       refreshBlock(player, targetLocation);
-      // for (EnumDirection direction : EnumDirection.values()) {
-      // Location placedBlock =
-      // targetLocation.clone().add(direction.getDirectionVec().convertToBukkitVec());
-      // refreshBlock(player, placedBlock);
-      // }
     });
   }
 


### PR DESCRIPTION
## Summary

This changes the BreakSpeedLimiter restart subcheck to use a delay-buffer based approach instead of directly flagging short restart timings.

The check now measures the delay between `STOP_DESTROY_BLOCK` and the next `START_DESTROY_BLOCK`, then accumulates the missing time compared to the expected restart delay. Normal restart timings decay the buffer again.

## Why

The old restart logic could false flag when legit block breaking produced very small server-side packet gaps, especially with click spam while mining. A single short restart delay should not be enough to flag.

## Changes

- Replaced hard restart timing thresholds with accumulated delay evidence
- Added decay for normal restart timings
- Ignored repeated `START_DESTROY_BLOCK` packets on the same active block

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I read the contribution guidelines and followed them.
- [x] No new class names contain "Utils", "Handler" or "Manager".

## Fixes
- #58 

## Reverts
- 11021382b58d01d32f8adbf9dbb62aec690b790e
