### PR TITLE
fix: persist final raytrace reach for heuristics

### DIFF
--- a/src/main/java/de/jpx3/intave/check/combat/AttackRaytrace.java
+++ b/src/main/java/de/jpx3/intave/check/combat/AttackRaytrace.java
@@ -636,6 +636,7 @@ public final class AttackRaytrace extends MetaCheck<AttackRaytrace.AttackRaytrac
     ViolationMetadata violationMeta = meta.violationLevel();
     String entityName = attacked.entityName();
     double blockReachDistance = Raytracing.reachDistanceOf(meta);
+    meta.attack().setLastReach(raytrace.reach());
     RaytraceResult result = RaytraceResult.of(raytrace, blockReachDistance);
     int vl = calculateVlFor(user, raytrace, result, attacked, expansion, estimated);
     String estimationSuffix = estimated ? " (estimated)" : "";


### PR DESCRIPTION
## Describe your changes

Adds the finalized attack raytrace result to AttackMetadata.lastReach, allowing reach-dependent combat heuristics to consume the calculated value instead of the default 0.0.

## What was your testing methodology?

## What systems are affected by my changes?
- `PreAttackHeuristic` — entire detection
- `AccuracyHitboxCornerHeuristic` — entire evaluation
- `RotationModuloResetHeuristic` — entire detection
- `RotationAccuracyYawHeuristic`
  - `checkSnap (lookEn)`
  - `checkHitboxCorners`

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I read the contribution guidelines and followed them.
- [x] No new class names contain "Utils", "Handler" or "Manager".
