### PR TITLE
Fix RotationSpeed false positives by bounding placement rotation samples by time

### DIFF
--- a/src/main/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeed.java
+++ b/src/main/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeed.java
@@ -21,6 +21,7 @@ import de.jpx3.intave.module.linker.bukkit.BukkitEventSubscription;
 import de.jpx3.intave.module.linker.packet.ListenerPriority;
 import de.jpx3.intave.module.linker.packet.PacketSubscription;
 import de.jpx3.intave.module.violation.Violation;
+import de.jpx3.intave.module.violation.ViolationContext;
 import de.jpx3.intave.user.User;
 import de.jpx3.intave.user.meta.MovementMetadata;
 import org.bukkit.block.Block;
@@ -40,8 +41,11 @@ import static de.jpx3.intave.module.violation.Violation.ViolationFlags.DISPLAY_I
 public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 	private static final int QUEUE_SIZE = 12;
 	private static final int MIN_ACTIVATION_DATA = 4;
+	private static final int MAX_ROTATION_SAMPLES = 5 * 20;
+	private static final long ROTATION_WINDOW_MS = 5000;
+	private static final double PREVENTION_VL = 20;
 	private final int rotationLimit;
-	private final List<Float> rotationHistory = new CopyOnWriteArrayList<>();
+	private final List<RotationSample> rotationHistory = new CopyOnWriteArrayList<>();
 	private final List<PlacedBlock> placementHistory = new CopyOnWriteArrayList<>();
 	private long lastBlockPlacement;
 	private long denyPlacementRequest;
@@ -62,28 +66,27 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 		User user = userOf(player);
 		MovementMetadata movementData = user.meta().movement();
 		float rotationMovement = Math.min(MathHelper.distanceInDegrees(movementData.rotationYaw, movementData.lastRotationYaw), 360);
-		if (System.currentTimeMillis() - lastBlockPlacement > 1000 || movementData.ticksPast(TELEPORT) <= 5) {
+		long now = System.currentTimeMillis();
+		if (now - lastBlockPlacement > 1000 || movementData.ticksPast(TELEPORT) <= 5) {
+			discardExpiredRotations(rotationHistory, now);
 			return;
 		}
-		List<Float> rotationHistory = this.rotationHistory;
-		if (rotationHistory.size() > 5 * 20) {
-			rotationHistory.remove(0);
-		}
-		rotationHistory.add(rotationMovement);
+		recordRotation(rotationHistory, rotationMovement, now);
 	}
 
 	@BukkitEventSubscription
 	public void on(BlockPlaceEvent place) {
 		Player player = place.getPlayer();
 		User user = userOf(player);
-		lastBlockPlacement = System.currentTimeMillis();
+		long now = System.currentTimeMillis();
+		lastBlockPlacement = now;
 
 		Block blockAgainst = place.getBlockAgainst();
 		if (blockAgainst == null) {
 			return;
 		}
 
-		if (System.currentTimeMillis() - denyPlacementRequest < 3000) {
+		if (now - denyPlacementRequest < 3000) {
 			place.setCancelled(true);
 			return;
 		}
@@ -92,11 +95,7 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 		boolean enoughBlockSamples = placementHistory.size() >= MIN_ACTIVATION_DATA;
 
 		if (placedBelow && enoughBlockSamples && isBridgeCreation(placementHistory)) {
-			List<Float> rotationHistory = this.rotationHistory;
-			double rotationSum = 0.0;
-			for (Float value : rotationHistory) {
-				rotationSum += value;
-			}
+			double rotationSum = rotationSum(rotationHistory, now);
 
 			float limit = rotationLimit;
 			if (!user.trustFactor().atLeast(TrustFactor.ORANGE)) {
@@ -112,10 +111,13 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 					.appendFlags(DISPLAY_IN_ALL_VERBOSE_MODES)
 					.withCustomThreshold(PlacementAnalysis.legacyConfigurationLayout() ? "thresholds" : "cloud-thresholds.on-premise")
 					.withVL(10).build();
-				Modules.violationProcessor().processViolation(violation);
-				denyPlacementRequest = System.currentTimeMillis();
-				user.meta().violationLevel().lastBlockPlaceDenyRequest = System.currentTimeMillis();
-				place.setCancelled(true);
+				ViolationContext violationContext = Modules.violationProcessor().processViolation(violation);
+				rotationHistory.clear();
+				if (violationContext.violationLevelAfter() > PREVENTION_VL) {
+					denyPlacementRequest = now;
+					user.meta().violationLevel().lastBlockPlaceDenyRequest = now;
+					place.setCancelled(true);
+				}
 			}
 		}
 		if (place.isCancelled()) {
@@ -127,6 +129,28 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 		Vector blockPosition = place.getBlock().getLocation().toVector();
 		Vector blockAgainstPosition = blockAgainst.getLocation().toVector();
 		placementHistory.add(new PlacedBlock(blockPosition, blockAgainstPosition));
+	}
+
+	static void recordRotation(List<RotationSample> history, float movement, long now) {
+		discardExpiredRotations(history, now);
+		if (history.size() >= MAX_ROTATION_SAMPLES) {
+			history.remove(0);
+		}
+		history.add(new RotationSample(movement, now));
+	}
+
+	static double rotationSum(List<RotationSample> history, long now) {
+		discardExpiredRotations(history, now);
+		double sum = 0.0;
+		for (RotationSample sample : history) {
+			sum += sample.movement;
+		}
+		return sum;
+	}
+
+	private static void discardExpiredRotations(List<RotationSample> history, long now) {
+		long cutoff = now - ROTATION_WINDOW_MS;
+		history.removeIf(sample -> sample.timestamp < cutoff);
 	}
 
 	private boolean isBridgeCreation(List<PlacedBlock> blocks) {
@@ -159,6 +183,16 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 		public PlacedBlock(Vector position, Vector placedAgainstPosition) {
 			this.placedAgainstPosition = placedAgainstPosition;
 			this.position = position;
+		}
+	}
+
+	static final class RotationSample {
+		private final float movement;
+		private final long timestamp;
+
+		RotationSample(float movement, long timestamp) {
+			this.movement = movement;
+			this.timestamp = timestamp;
 		}
 	}
 

--- a/src/main/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeed.java
+++ b/src/main/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeed.java
@@ -41,8 +41,12 @@ import static de.jpx3.intave.module.violation.Violation.ViolationFlags.DISPLAY_I
 public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 	private static final int QUEUE_SIZE = 12;
 	private static final int MIN_ACTIVATION_DATA = 4;
+	// Rotation activity represents one recent bridging sequence. Bounding it by
+	// both time and count prevents old sequences from contaminating a new one.
 	private static final int MAX_ROTATION_SAMPLES = 5 * 20;
 	private static final long ROTATION_WINDOW_MS = 5000;
+	// Report suspicious activity first; only deny placements after the shared
+	// violation processor confirms that the player crossed a sustained threshold.
 	private static final double PREVENTION_VL = 20;
 	private final int rotationLimit;
 	private final List<RotationSample> rotationHistory = new CopyOnWriteArrayList<>();
@@ -68,6 +72,8 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 		float rotationMovement = Math.min(MathHelper.distanceInDegrees(movementData.rotationYaw, movementData.lastRotationYaw), 360);
 		long now = System.currentTimeMillis();
 		if (now - lastBlockPlacement > 1000 || movementData.ticksPast(TELEPORT) <= 5) {
+			// Expire samples while collection is inactive so the next bridge cannot
+			// inherit rotation activity from an older sequence.
 			discardExpiredRotations(rotationHistory, now);
 			return;
 		}
@@ -95,6 +101,8 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 		boolean enoughBlockSamples = placementHistory.size() >= MIN_ACTIVATION_DATA;
 
 		if (placedBelow && enoughBlockSamples && isBridgeCreation(placementHistory)) {
+			// Sum only the current window. A count-only history could combine
+			// multiple legitimate bridging sequences into one violation.
 			double rotationSum = rotationSum(rotationHistory, now);
 
 			float limit = rotationLimit;
@@ -112,7 +120,11 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 					.withCustomThreshold(PlacementAnalysis.legacyConfigurationLayout() ? "thresholds" : "cloud-thresholds.on-premise")
 					.withVL(10).build();
 				ViolationContext violationContext = Modules.violationProcessor().processViolation(violation);
+				// Consume this evidence after reporting it. Reusing the same rotation
+				// burst on following placements would repeatedly add violation level.
 				rotationHistory.clear();
+				// One unusual sequence may alert, but cannot immediately cancel building.
+				// Prevention starts only after the shared VL has accumulated.
 				if (violationContext.violationLevelAfter() > PREVENTION_VL) {
 					denyPlacementRequest = now;
 					user.meta().violationLevel().lastBlockPlaceDenyRequest = now;
@@ -132,6 +144,8 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 	}
 
 	static void recordRotation(List<RotationSample> history, float movement, long now) {
+		// Time expiry defines the activity window; the count cap is a defensive
+		// memory bound for clients sending unusually many look packets.
 		discardExpiredRotations(history, now);
 		if (history.size() >= MAX_ROTATION_SAMPLES) {
 			history.remove(0);
@@ -140,6 +154,8 @@ public final class RotationSpeed extends PlayerCheckPart<PlacementAnalysis> {
 	}
 
 	static double rotationSum(List<RotationSample> history, long now) {
+		// Prune at read time because a placement may occur without another look
+		// packet that would otherwise trigger recordRotation().
 		discardExpiredRotations(history, now);
 		double sum = 0.0;
 		for (RotationSample sample : history) {

--- a/src/test/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeedTest.java
+++ b/src/test/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeedTest.java
@@ -1,0 +1,40 @@
+package de.jpx3.intave.check.world.placementanalysis;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RotationSpeedTest {
+  @Test
+  void ignoresSamplesOutsideTheRotationWindow() {
+    List<RotationSpeed.RotationSample> history = new ArrayList<>();
+    RotationSpeed.recordRotation(history, 100.0F, 0);
+    RotationSpeed.recordRotation(history, 200.0F, 4999);
+
+    assertEquals(200.0, RotationSpeed.rotationSum(history, 5001));
+    assertEquals(1, history.size());
+  }
+
+  @Test
+  void keepsSamplesOnTheWindowBoundary() {
+    List<RotationSpeed.RotationSample> history = new ArrayList<>();
+    RotationSpeed.recordRotation(history, 100.0F, 0);
+
+    assertEquals(100.0, RotationSpeed.rotationSum(history, 5000));
+    assertEquals(1, history.size());
+  }
+
+  @Test
+  void capsTheNumberOfRotationSamples() {
+    List<RotationSpeed.RotationSample> history = new ArrayList<>();
+    for (int i = 0; i < 101; i++) {
+      RotationSpeed.recordRotation(history, 1.0F, i);
+    }
+
+    assertEquals(100, history.size());
+    assertEquals(100.0, RotationSpeed.rotationSum(history, 101));
+  }
+}

--- a/src/test/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeedTest.java
+++ b/src/test/java/de/jpx3/intave/check/world/placementanalysis/RotationSpeedTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// Regression coverage for the semantic five-second activity window and the
+// independent defensive 100-sample memory bound.
 class RotationSpeedTest {
   @Test
   void ignoresSamplesOutsideTheRotationWindow() {
@@ -23,6 +25,7 @@ class RotationSpeedTest {
     List<RotationSpeed.RotationSample> history = new ArrayList<>();
     RotationSpeed.recordRotation(history, 100.0F, 0);
 
+    // Samples exactly on the cutoff remain part of the active window.
     assertEquals(100.0, RotationSpeed.rotationSum(history, 5000));
     assertEquals(1, history.size());
   }


### PR DESCRIPTION
## Describe your changes

`placementanalysis`'s `RotationSpeed` check summed a rotation activity history that was
bounded only by sample count, never by time. Rotation from an earlier bridging sequence
therefore bled into the next one, and a single suspicious burst was reused across
subsequent placements repeatedly inflating the violation level and immediately
cancelling legitimate building. The result was sustained false positives against
legit bridgers. 

Changes: 
- Replace the count-only `List<Float>` history with timestamped `RotationSample`s bounded
  by a 5s activity window (`ROTATION_WINDOW_MS`). Expired samples are pruned on record
  on read, and while collection is idle, so an old sequence can no longer contaminate a new
  one. The existing 5 * 20 count cap is kept purely as a defensive memory bound against
  clients sending unusually many look packets
- Consume the evidence(`rotationHistory.clear()`) once a violation is reported, so the
  same burst cannot keep adding VL on following placements.
- a single unusual sequence still alerts but placements are
  only cancelled once the shared violation processor confirms a sustained level
  (`violationLevelAfter() > PREVENTION_VL`, 20). This only reads the `ViolationContext`
  already returned by `processViolation()`; the processor itself is unchanged.

## What was your testing methodology?

- Unit tests (`RotationSpeedTest`): samples outside the 5s window are excluded from the
  sum, a sample exactly on the cutoff is retained, and the 100 sample memory cap holds.
- Live A/B on a 1.8.8 production network: the patched build ran on one game server with
  `placementanalysis` enabled while the rest of the network stayed on the unpatched build as
  a control. Over an ~8h session with ~30 players actively bridging, the check produced
  0 false positives, versus the prefix build where legit bridging reached
  VL ~85 within minutes. Ping (26 ms) and TPS (20.0) stayed flat throughout, ruling out
  lag as a cause. Performed a selfreview of my code to an possible extent.  

## What systems are affected by my changes?

Only the `RotationSpeed` sub-check in `check/world/placementanalysis`. No other checks no
shared movement/combat/violation infrastructure, and no public API the violation processor
is only read from (its existing `ViolationContext` return value) not modified

## Checklist before requesting a review 
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if other critical systems rely on my changes.
- [x] I read the contribution guidelines and followed them.
- [x] No new class names contain "Utils", "Handler" or "Manager". 
