### PR TITLE
improve performance of formatDouble

### DIFF
--- a/src/main/java/de/jpx3/intave/math/MathHelper.java
+++ b/src/main/java/de/jpx3/intave/math/MathHelper.java
@@ -42,7 +42,7 @@ public final class MathHelper {
     if (Double.isInfinite(value)) {
       return "Infinite";
     }
-    if(digits > 10 || value > 1000000.0) {
+    if(digits > 10 || Math.abs(value) > 1000000.0) {
       return BigDecimal.valueOf(value).setScale(digits, RoundingMode.HALF_UP).toPlainString(); // BigDecimal.valueOf is slightly faster than new BigDecimal(value)
     }
     double scaledValue = value * POWERS_OF_TEN[digits] + ((value < 0.0) ? -0.5 : 0.5); // -0.5, +0.5 for rounding

--- a/src/main/java/de/jpx3/intave/math/MathHelper.java
+++ b/src/main/java/de/jpx3/intave/math/MathHelper.java
@@ -10,6 +10,20 @@ import java.math.RoundingMode;
 import java.util.List;
 
 public final class MathHelper {
+    private static final long[] POWERS_OF_TEN = {
+                 1L,
+                10L,
+               100L,
+             1_000L,
+            10_000L,
+           100_000L,
+         1_000_000L,
+        10_000_000L,
+       100_000_000L,
+     1_000_000_000L,
+    10_000_000_000L
+  };
+  
   public static double averageOf(List<? extends Number> data) {
     double sum = 0;
     for (Number element : data) {
@@ -28,7 +42,23 @@ public final class MathHelper {
     if (Double.isInfinite(value)) {
       return "Infinite";
     }
-    return new BigDecimal(value).setScale(digits, RoundingMode.HALF_UP).toPlainString();
+    if(digits > 10 || value > 1000000.0) {
+      return BigDecimal.valueOf(value).setScale(digits, RoundingMode.HALF_UP).toPlainString(); // BigDecimal.valueOf is slightly faster than new BigDecimal(value)
+    }
+    double scaledValue = value * POWERS_OF_TEN[digits] + ((value < 0.0) ? -0.5 : 0.5); // -0.5, +0.5 for rounding
+    long num = (long)scaledValue;
+    int negative = num < 0 ? 1 : 0;
+    StringBuilder sb = new StringBuilder();
+    sb.append(num);
+    int len = sb.length() - negative;
+    if(len < digits+1) {
+      int leadingZero = digits+1-len;
+      sb.insert(negative, "00000000000", 0, leadingZero);
+    }
+    if(digits > 0) {
+      sb.insert(sb.length()-digits, ".");
+    }
+    return sb.toString();
   }
 
   public static String decimalPlacesOf(double value, int digits) {


### PR DESCRIPTION
## Describe your changes
Added lower cost path for formatDouble to address 
fixes #135 

## What was your testing methodology?
I wrote a short (not great) 
program to check timing and differences between BigInteger's formatting and the short path. this program can be found in this attachment.
[Main.java](https://github.com/user-attachments/files/30482068/Main.java)

## What systems are affected by my changes?
Anything that uses the formatDouble method of the MathHelper class should be affected minimally and anything that requires higher precision (notably instances in AttackRaytrace) should in theory use the same higher precision path as before.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests if other critical systems rely on my changes.
- [x] I read the contribution guidelines and followed them.
- [x] No new class names contain "Utils", "Handler" or "Manager".

P.S. I wasn't sure about making and submitting a change myself as I don't have the required confidence in my code but I decided to do it anyway as it would maybe help.