### PR TITLE
fix: handle bubble column physics correctly on 1.21.7+

### DIFF
--- a/src/main/java/de/jpx3/intave/block/intersection/BlockIntersection.java
+++ b/src/main/java/de/jpx3/intave/block/intersection/BlockIntersection.java
@@ -1,6 +1,224 @@
+/*
+ * Copyright 2026 Intave
+ *
+ * This software is licensed under the PolyForm Perimeter License 1.0.0.
+ * You may use this software for any purpose, except for providing to
+ * others any product that competes with the software.
+ *
+ * A copy of the license is available at:
+ *   https://polyformproject.org/licenses/perimeter/1.0.0/
+ */
+
 package de.jpx3.intave.block.intersection;
 
-public interface BlockIntersection {
+import de.jpx3.intave.share.BlockPosition;
+import de.jpx3.intave.share.BoundingBox;
+import de.jpx3.intave.share.Motion;
+import de.jpx3.intave.share.Position;
+import de.jpx3.intave.share.RawVector3d;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 
+import static de.jpx3.intave.share.ClientMath.clamp_double;
+import static de.jpx3.intave.share.ClientMath.floor;
 
+/**
+ * Finds blocks touched by an entity between two positions.
+ *
+ * <p>This follows the 1.21.7 {@code BlockGetter.forEachBlockIntersectedBetween}
+ * behavior. The step number and early exit are kept because the generic
+ * inside-block effect collector can use both when several effects overlap.</p>
+ */
+public final class BlockIntersection {
+  private static final double SHORT_MOVEMENT_LIMIT = 0.99999F * 0.99999F;
+  private static final double HIT_EPSILON = 1.0E-5F;
+  private static final int MAX_TRAVEL_STEPS = 16;
+
+  private BlockIntersection() {
+  }
+
+  public static boolean forEachBlockIntersectedBetween(
+    Position from, Position to, BoundingBox destinationBox, BlockStepVisitor visitor
+  ) {
+    Motion movement = from.motionTo(to);
+    if (movement.lengthSquared() < SHORT_MOVEMENT_LIMIT) {
+      return visitBox(destinationBox, 0, null, visitor);
+    }
+
+    LongSet visited = new LongOpenHashSet();
+    Position destinationMin = new Position(
+      destinationBox.minX, destinationBox.minY, destinationBox.minZ
+    );
+    Position originMin = destinationMin.add(
+      -movement.motionX, -movement.motionY, -movement.motionZ
+    );
+    int step = addCollisionsAlongTravel(
+      visited, originMin, destinationMin, destinationBox, visitor
+    );
+    return step >= 0 && visitBox(destinationBox, step + 1, visited, visitor);
+  }
+
+  private static int addCollisionsAlongTravel(
+    LongSet visited,
+    Position from, Position to,
+    BoundingBox destinationBox,
+    BlockStepVisitor visitor
+  ) {
+    Motion movement = from.motionTo(to);
+    int x = floor(from.getX());
+    int y = floor(from.getY());
+    int z = floor(from.getZ());
+    int stepX = sign(movement.motionX);
+    int stepY = sign(movement.motionY);
+    int stepZ = sign(movement.motionZ);
+    double intervalX = stepX == 0 ? Double.MAX_VALUE : stepX / movement.motionX;
+    double intervalY = stepY == 0 ? Double.MAX_VALUE : stepY / movement.motionY;
+    double intervalZ = stepZ == 0 ? Double.MAX_VALUE : stepZ / movement.motionZ;
+    double nextX = intervalX * (stepX > 0 ? 1.0 - fraction(from.getX()) : fraction(from.getX()));
+    double nextY = intervalY * (stepY > 0 ? 1.0 - fraction(from.getY()) : fraction(from.getY()));
+    double nextZ = intervalZ * (stepZ > 0 ? 1.0 - fraction(from.getZ()) : fraction(from.getZ()));
+    int step = 0;
+
+    while (nextX <= 1.0 || nextY <= 1.0 || nextZ <= 1.0) {
+      if (nextX < nextY) {
+        if (nextX < nextZ) {
+          x += stepX;
+          nextX += intervalX;
+        } else {
+          z += stepZ;
+          nextZ += intervalZ;
+        }
+      } else if (nextY < nextZ) {
+        y += stepY;
+        nextY += intervalY;
+      } else {
+        z += stepZ;
+        nextZ += intervalZ;
+      }
+
+      if (step++ > MAX_TRAVEL_STEPS) {
+        break;
+      }
+
+      RawVector3d hit = clipUnitBlock(x, y, z, from, to);
+      if (hit == null) {
+        continue;
+      }
+
+      double hitX = clamp_double(hit.x(), x + HIT_EPSILON, x + 1.0 - HIT_EPSILON);
+      double hitY = clamp_double(hit.y(), y + HIT_EPSILON, y + 1.0 - HIT_EPSILON);
+      double hitZ = clamp_double(hit.z(), z + HIT_EPSILON, z + 1.0 - HIT_EPSILON);
+      int endX = floor(hitX + destinationBox.maxX - destinationBox.minX);
+      int endY = floor(hitY + destinationBox.maxY - destinationBox.minY);
+      int endZ = floor(hitZ + destinationBox.maxZ - destinationBox.minZ);
+
+      for (int blockX = x; blockX <= endX; blockX++) {
+        for (int blockY = y; blockY <= endY; blockY++) {
+          for (int blockZ = z; blockZ <= endZ; blockZ++) {
+            BlockPosition blockPosition = new BlockPosition(blockX, blockY, blockZ);
+            if (visited.add(blockPosition.toLong()) && !visitor.visit(blockPosition, step)) {
+              return -1;
+            }
+          }
+        }
+      }
+    }
+    return step;
+  }
+
+  private static boolean visitBox(
+    BoundingBox box, int step, LongSet visited, BlockStepVisitor visitor
+  ) {
+    int minX = floor(box.minX);
+    int minY = floor(box.minY);
+    int minZ = floor(box.minZ);
+    int maxX = floor(box.maxX);
+    int maxY = floor(box.maxY);
+    int maxZ = floor(box.maxZ);
+
+    for (int x = minX; x <= maxX; x++) {
+      for (int y = minY; y <= maxY; y++) {
+        for (int z = minZ; z <= maxZ; z++) {
+          BlockPosition blockPosition = new BlockPosition(x, y, z);
+          if ((visited == null || !visited.contains(blockPosition.toLong()))
+            && !visitor.visit(blockPosition, step)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  private static RawVector3d clipUnitBlock(
+    int x, int y, int z, Position from, Position to
+  ) {
+    double movementX = to.getX() - from.getX();
+    double movementY = to.getY() - from.getY();
+    double movementZ = to.getZ() - from.getZ();
+    double nearest = 1.0;
+    nearest = clipPoint(
+      nearest, movementX, movementY, movementZ,
+      movementX > 1.0E-7 ? x : x + 1,
+      y, y + 1, z, z + 1,
+      from.getX(), from.getY(), from.getZ()
+    );
+    nearest = clipPoint(
+      nearest, movementY, movementZ, movementX,
+      movementY > 1.0E-7 ? y : y + 1,
+      z, z + 1, x, x + 1,
+      from.getY(), from.getZ(), from.getX()
+    );
+    nearest = clipPoint(
+      nearest, movementZ, movementX, movementY,
+      movementZ > 1.0E-7 ? z : z + 1,
+      x, x + 1, y, y + 1,
+      from.getZ(), from.getX(), from.getY()
+    );
+    if (nearest >= 1.0) {
+      return null;
+    }
+    return new RawVector3d(
+      from.getX() + nearest * movementX,
+      from.getY() + nearest * movementY,
+      from.getZ() + nearest * movementZ
+    );
+  }
+
+  private static double clipPoint(
+    double nearest,
+    double movement, double otherMovementA, double otherMovementB,
+    double plane,
+    double minA, double maxA, double minB, double maxB,
+    double start, double otherStartA, double otherStartB
+  ) {
+    if (Math.abs(movement) <= 1.0E-7) {
+      return nearest;
+    }
+    double distance = (plane - start) / movement;
+    double intersectionA = otherStartA + distance * otherMovementA;
+    double intersectionB = otherStartB + distance * otherMovementB;
+    if (0.0 < distance && distance < nearest
+      && minA - 1.0E-7 < intersectionA && intersectionA < maxA + 1.0E-7
+      && minB - 1.0E-7 < intersectionB && intersectionB < maxB + 1.0E-7) {
+      return distance;
+    }
+    return nearest;
+  }
+
+  private static int sign(double value) {
+    return value < 0.0 ? -1 : value > 0.0 ? 1 : 0;
+  }
+
+  private static double fraction(double value) {
+    return value - floor(value);
+  }
+
+  @FunctionalInterface
+  public interface BlockStepVisitor {
+    /**
+     * @return {@code false} to stop traversing
+     */
+    boolean visit(BlockPosition blockPosition, int step);
+  }
 }

--- a/src/main/java/de/jpx3/intave/block/intersection/BlockIntersection.java
+++ b/src/main/java/de/jpx3/intave/block/intersection/BlockIntersection.java
@@ -25,9 +25,7 @@ import static de.jpx3.intave.share.ClientMath.floor;
 /**
  * Finds blocks touched by an entity between two positions.
  *
- * <p>This follows the 1.21.7 {@code BlockGetter.forEachBlockIntersectedBetween}
- * behavior. The step number and early exit are kept because the generic
- * inside-block effect collector can use both when several effects overlap.</p>
+ * <p>Implements the client traversal variants used by inside-block effects.</p>
  */
 public final class BlockIntersection {
   private static final double SHORT_MOVEMENT_LIMIT = 0.99999F * 0.99999F;
@@ -56,6 +54,22 @@ public final class BlockIntersection {
       visited, originMin, destinationMin, destinationBox, visitor
     );
     return step >= 0 && visitBox(destinationBox, step + 1, visited, visitor);
+  }
+
+  public static boolean forEachBlockIntersectedBetweenDirectional(
+    Position from, Position to, BoundingBox destinationBox, BlockStepVisitor visitor
+  ) {
+    return DirectionalBlockIntersection.forEachBlockIntersectedBetween(
+      from, to, destinationBox, visitor
+    );
+  }
+
+  public static boolean isPreciseIntersection(
+    Position from, Position to, BoundingBox destinationBox, BlockPosition blockPosition
+  ) {
+    return DirectionalBlockIntersection.isPreciseIntersection(
+      from, to, destinationBox, blockPosition
+    );
   }
 
   private static int addCollisionsAlongTravel(
@@ -126,7 +140,7 @@ public final class BlockIntersection {
     return step;
   }
 
-  private static boolean visitBox(
+  static boolean visitBox(
     BoundingBox box, int step, LongSet visited, BlockStepVisitor visitor
   ) {
     int minX = floor(box.minX);
@@ -150,7 +164,7 @@ public final class BlockIntersection {
     return true;
   }
 
-  private static RawVector3d clipUnitBlock(
+  static RawVector3d clipUnitBlock(
     int x, int y, int z, Position from, Position to
   ) {
     double movementX = to.getX() - from.getX();
@@ -206,11 +220,11 @@ public final class BlockIntersection {
     return nearest;
   }
 
-  private static int sign(double value) {
+  static int sign(double value) {
     return value < 0.0 ? -1 : value > 0.0 ? 1 : 0;
   }
 
-  private static double fraction(double value) {
+  static double fraction(double value) {
     return value - floor(value);
   }
 

--- a/src/main/java/de/jpx3/intave/block/intersection/DirectionalBlockIntersection.java
+++ b/src/main/java/de/jpx3/intave/block/intersection/DirectionalBlockIntersection.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 Intave
+ *
+ * This software is licensed under the PolyForm Perimeter License 1.0.0.
+ * You may use this software for any purpose, except for providing to
+ * others any product that competes with the software.
+ *
+ * A copy of the license is available at:
+ *   https://polyformproject.org/licenses/perimeter/1.0.0/
+ */
+
+package de.jpx3.intave.block.intersection;
+
+import de.jpx3.intave.share.BlockPosition;
+import de.jpx3.intave.share.BoundingBox;
+import de.jpx3.intave.share.Direction;
+import de.jpx3.intave.share.Motion;
+import de.jpx3.intave.share.Position;
+import de.jpx3.intave.share.RawVector3d;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
+import java.util.List;
+
+import static de.jpx3.intave.share.ClientMath.clamp_double;
+import static de.jpx3.intave.share.ClientMath.floor;
+
+final class DirectionalBlockIntersection {
+  private static final double PRECISE_MOVEMENT_LIMIT =
+    0.9999900000002526 * 0.9999900000002526;
+  private static final double MIN_MOVEMENT_LIMIT = 1.0E-5F * 1.0E-5F;
+  private static final double HIT_EPSILON = 1.0E-5F;
+  private static final int MAX_TRAVEL_STEPS = 16;
+
+  private DirectionalBlockIntersection() {
+  }
+
+  static boolean forEachBlockIntersectedBetween(
+    Position from,
+    Position to,
+    BoundingBox destinationBox,
+    BlockIntersection.BlockStepVisitor visitor
+  ) {
+    Motion movement = from.motionTo(to);
+    if (movement.lengthSquared() < MIN_MOVEMENT_LIMIT) {
+      return BlockIntersection.visitBox(destinationBox, 0, null, visitor);
+    }
+
+    LongSet visited = new LongOpenHashSet();
+    BoundingBox originBox = destinationBox.move(
+      -movement.motionX, -movement.motionY, -movement.motionZ
+    );
+    if (!visitBox(originBox, movement, 0, visited, visitor)) {
+      return false;
+    }
+
+    int step = addCollisionsAlongTravel(
+      visited, movement, destinationBox, visitor
+    );
+    return step >= 0
+      && visitBox(destinationBox, movement, step + 1, visited, visitor);
+  }
+
+  static boolean isPreciseIntersection(
+    Position from,
+    Position to,
+    BoundingBox destinationBox,
+    BlockPosition blockPosition
+  ) {
+    return from.distanceSquared(to) > PRECISE_MOVEMENT_LIMIT
+      || destinationBox.intersectsWith(
+        blockPosition.getX(), blockPosition.getY(), blockPosition.getZ(),
+        blockPosition.getX() + 1.0,
+        blockPosition.getY() + 1.0,
+        blockPosition.getZ() + 1.0
+      );
+  }
+
+  private static int addCollisionsAlongTravel(
+    LongSet visited,
+    Motion movement,
+    BoundingBox destinationBox,
+    BlockIntersection.BlockStepVisitor visitor
+  ) {
+    int[] corner = furthestCorner(movement);
+    double sizeX = destinationBox.maxX - destinationBox.minX;
+    double sizeY = destinationBox.maxY - destinationBox.minY;
+    double sizeZ = destinationBox.maxZ - destinationBox.minZ;
+    Position toCorner = new Position(
+      destinationBox.centerX() + sizeX * 0.5 * corner[0],
+      destinationBox.centerY() + sizeY * 0.5 * corner[1],
+      destinationBox.centerZ() + sizeZ * 0.5 * corner[2]
+    );
+    Position fromCorner = toCorner.add(
+      -movement.motionX, -movement.motionY, -movement.motionZ
+    );
+    int x = floor(fromCorner.getX());
+    int y = floor(fromCorner.getY());
+    int z = floor(fromCorner.getZ());
+    int stepX = BlockIntersection.sign(movement.motionX);
+    int stepY = BlockIntersection.sign(movement.motionY);
+    int stepZ = BlockIntersection.sign(movement.motionZ);
+    double intervalX = stepX == 0 ? Double.MAX_VALUE : stepX / movement.motionX;
+    double intervalY = stepY == 0 ? Double.MAX_VALUE : stepY / movement.motionY;
+    double intervalZ = stepZ == 0 ? Double.MAX_VALUE : stepZ / movement.motionZ;
+    double nextX = intervalX
+      * (stepX > 0
+      ? 1.0 - BlockIntersection.fraction(fromCorner.getX())
+      : BlockIntersection.fraction(fromCorner.getX()));
+    double nextY = intervalY
+      * (stepY > 0
+      ? 1.0 - BlockIntersection.fraction(fromCorner.getY())
+      : BlockIntersection.fraction(fromCorner.getY()));
+    double nextZ = intervalZ
+      * (stepZ > 0
+      ? 1.0 - BlockIntersection.fraction(fromCorner.getZ())
+      : BlockIntersection.fraction(fromCorner.getZ()));
+    int step = 0;
+
+    while (nextX <= 1.0 || nextY <= 1.0 || nextZ <= 1.0) {
+      if (nextX < nextY) {
+        if (nextX < nextZ) {
+          x += stepX;
+          nextX += intervalX;
+        } else {
+          z += stepZ;
+          nextZ += intervalZ;
+        }
+      } else if (nextY < nextZ) {
+        y += stepY;
+        nextY += intervalY;
+      } else {
+        z += stepZ;
+        nextZ += intervalZ;
+      }
+
+      if (step >= MAX_TRAVEL_STEPS) {
+        break;
+      }
+
+      RawVector3d hit = BlockIntersection.clipUnitBlock(
+        x, y, z, fromCorner, toCorner
+      );
+      if (hit == null) {
+        continue;
+      }
+
+      step++;
+      double hitX = clamp_double(hit.x(), x + HIT_EPSILON, x + 1.0 - HIT_EPSILON);
+      double hitY = clamp_double(hit.y(), y + HIT_EPSILON, y + 1.0 - HIT_EPSILON);
+      double hitZ = clamp_double(hit.z(), z + HIT_EPSILON, z + 1.0 - HIT_EPSILON);
+      int endX = floor(hitX - sizeX * corner[0]);
+      int endY = floor(hitY - sizeY * corner[1]);
+      int endZ = floor(hitZ - sizeZ * corner[2]);
+
+      if (!visitBox(
+        x, y, z, endX, endY, endZ,
+        movement, step, visited, visitor
+      )) {
+        return -1;
+      }
+    }
+    return step;
+  }
+
+  private static int[] furthestCorner(Motion movement) {
+    double x = Math.abs(movement.motionX);
+    double y = Math.abs(movement.motionY);
+    double z = Math.abs(movement.motionZ);
+    int signX = movement.motionX >= 0.0 ? 1 : -1;
+    int signY = movement.motionY >= 0.0 ? 1 : -1;
+    int signZ = movement.motionZ >= 0.0 ? 1 : -1;
+    if (x <= y && x <= z) {
+      return new int[]{-signX, -signZ, signY};
+    }
+    if (y <= z) {
+      return new int[]{signZ, -signY, -signX};
+    }
+    return new int[]{-signY, signX, -signZ};
+  }
+
+  private static boolean visitBox(
+    BoundingBox box,
+    Motion movement,
+    int step,
+    LongSet visited,
+    BlockIntersection.BlockStepVisitor visitor
+  ) {
+    return visitBox(
+      floor(box.minX), floor(box.minY), floor(box.minZ),
+      floor(box.maxX), floor(box.maxY), floor(box.maxZ),
+      movement, step, visited, visitor
+    );
+  }
+
+  private static boolean visitBox(
+    int firstX, int firstY, int firstZ,
+    int secondX, int secondY, int secondZ,
+    Motion movement,
+    int step,
+    LongSet visited,
+    BlockIntersection.BlockStepVisitor visitor
+  ) {
+    int minX = Math.min(firstX, secondX);
+    int minY = Math.min(firstY, secondY);
+    int minZ = Math.min(firstZ, secondZ);
+    int maxX = Math.max(firstX, secondX);
+    int maxY = Math.max(firstY, secondY);
+    int maxZ = Math.max(firstZ, secondZ);
+    int startX = movement.motionX >= 0.0 ? minX : maxX;
+    int startY = movement.motionY >= 0.0 ? minY : maxY;
+    int startZ = movement.motionZ >= 0.0 ? minZ : maxZ;
+    List<Direction.Axis> axes = Direction.axisStepOrder(movement);
+    Direction.Axis firstAxis = axes.get(0);
+    Direction.Axis secondAxis = axes.get(1);
+    Direction.Axis thirdAxis = axes.get(2);
+    Motion firstDirection =
+      (firstAxis.select(movement.motionX, movement.motionY, movement.motionZ) >= 0.0
+        ? firstAxis.positive() : firstAxis.negative()).normalMotion();
+    Motion secondDirection =
+      (secondAxis.select(movement.motionX, movement.motionY, movement.motionZ) >= 0.0
+        ? secondAxis.positive() : secondAxis.negative()).normalMotion();
+    Motion thirdDirection =
+      (thirdAxis.select(movement.motionX, movement.motionY, movement.motionZ) >= 0.0
+        ? thirdAxis.positive() : thirdAxis.negative()).normalMotion();
+    int firstMax = firstAxis.select(maxX - minX, maxY - minY, maxZ - minZ);
+    int secondMax = secondAxis.select(maxX - minX, maxY - minY, maxZ - minZ);
+    int thirdMax = thirdAxis.select(maxX - minX, maxY - minY, maxZ - minZ);
+
+    for (int first = 0; first <= firstMax; first++) {
+      for (int second = 0; second <= secondMax; second++) {
+        for (int third = 0; third <= thirdMax; third++) {
+          BlockPosition blockPosition = new BlockPosition(
+            startX
+              + (int) firstDirection.motionX * first
+              + (int) secondDirection.motionX * second
+              + (int) thirdDirection.motionX * third,
+            startY
+              + (int) firstDirection.motionY * first
+              + (int) secondDirection.motionY * second
+              + (int) thirdDirection.motionY * third,
+            startZ
+              + (int) firstDirection.motionZ * first
+              + (int) secondDirection.motionZ * second
+              + (int) thirdDirection.motionZ * third
+          );
+          if ((visited == null || visited.add(blockPosition.toLong()))
+            && !visitor.visit(blockPosition, step)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/de/jpx3/intave/block/physics/BubbleColumnPhysics.java
+++ b/src/main/java/de/jpx3/intave/block/physics/BubbleColumnPhysics.java
@@ -13,8 +13,10 @@ package de.jpx3.intave.block.physics;
 
 import de.jpx3.intave.adapter.MinecraftVersion;
 import de.jpx3.intave.block.access.VolatileBlockAccess;
+import de.jpx3.intave.block.fluid.Fluid;
 import de.jpx3.intave.block.variant.BlockVariant;
 import de.jpx3.intave.check.movement.physics.environment.SimulationEnvironment;
+import de.jpx3.intave.share.BlockPosition;
 import de.jpx3.intave.share.Motion;
 import de.jpx3.intave.user.User;
 import de.jpx3.intave.user.meta.MovementMetadata;
@@ -42,14 +44,17 @@ final class BubbleColumnPhysics implements BlockPhysic {
   public Motion entityInside(User user, SimulationEnvironment environment, Location location, Location from, double motionX, double motionY, double motionZ) {
     ProtocolMetadata protocol = user.meta().protocol();
     if (protocol.aquaticUpdate()) {
-      boolean water = VolatileBlockAccess.fluidAccess(user, location.clone().add(0, 1, 0)).isOfWater();
+      BlockPosition above = new BlockPosition(location).up();
+      Fluid fluidAbove = VolatileBlockAccess.fluidAccess(user, above);
+      boolean surface = protocol.newBlockEntityIntersectionLogic()
+        ? fluidAbove.isDry() && user.blockCache().collisionShapeAt(above).isEmpty()
+        : !fluidAbove.isOfWater();
       BlockVariant variant = VolatileBlockAccess.variantAccess(user, location);
       boolean downwards = variant.propertyOf("drag");
-      if (water) {
-        return enterBubbleColumn(user, downwards, motionX, motionY, motionZ);
-      } else {
+      if (surface) {
         return enterBubbleColumnWithAirAbove(downwards, motionX, motionY, motionZ);
       }
+      return enterBubbleColumn(user, downwards, motionX, motionY, motionZ);
     }
     return null;
   }
@@ -71,7 +76,7 @@ final class BubbleColumnPhysics implements BlockPhysic {
     } else {
       motionY = Math.min(1.8D, motionY + 0.1D);
     }
-	  return new Motion(motionX, motionY, motionZ);
+    return new Motion(motionX, motionY, motionZ);
   }
 
   @Override

--- a/src/main/java/de/jpx3/intave/check/movement/physics/simulator/BaseSimulator.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/simulator/BaseSimulator.java
@@ -635,10 +635,16 @@ class BaseSimulator extends Simulator {
     Position from = environment.verifiedLastPosition();
     Position to = environment.position();
     Motion movement = from.motionTo(to);
+    Motion axisOrder = movement;
+    SimulationResult result = environment.simulationResult();
+    if (user.meta().protocol().directionalBlockEntityIntersectionLogic()
+      && result != null && result.intermittentResult() != null) {
+      axisOrder = result.intermittentResult();
+    }
     LongSet visitedBlocks = new LongOpenHashSet();
 
     if (movement.lengthSquared() > 0.0) {
-      for (Direction.Axis axis : Direction.axisStepOrder(movement)) {
+      for (Direction.Axis axis : Direction.axisStepOrder(axisOrder)) {
         double movementOnAxis = movement.partialMotionIn(axis);
         if (movementOnAxis != 0.0) {
           Position axisDestination = from.relative(axis.positive(), movementOnAxis);
@@ -664,14 +670,17 @@ class BaseSimulator extends Simulator {
     Location movementTarget = to.toLocation(world);
     BoundingBox destinationBox =
       BoundingBox.fromPosition(user, environment, to).shrink(1.0E-5F);
-    BlockIntersection.forEachBlockIntersectedBetween(
-      from, to, destinationBox,
+    BlockIntersection.BlockStepVisitor visitor =
       (blockPosition, ignoredStep) -> {
-        if (!visitedBlocks.add(blockPosition.toLong())) {
+        Material material = VolatileBlockAccess.typeAccess(user, blockPosition);
+        if (material != BlockTypeAccess.BUBBLE_COLUMN
+          || !visitedBlocks.add(blockPosition.toLong())) {
           return true;
         }
-        Material material = VolatileBlockAccess.typeAccess(user, blockPosition);
-        if (material != BlockTypeAccess.BUBBLE_COLUMN) {
+        if (user.meta().protocol().directionalBlockEntityIntersectionLogic()
+          && !BlockIntersection.isPreciseIntersection(
+          from, to, destinationBox, blockPosition
+        )) {
           return true;
         }
         Motion collisionMotion = BlockPhysics.entityInside(
@@ -683,8 +692,17 @@ class BaseSimulator extends Simulator {
           motion.setTo(collisionMotion);
         }
         return true;
-      }
-    );
+      };
+    if (user.meta().protocol().directionalBlockEntityIntersectionLogic()) {
+      BlockIntersection.forEachBlockIntersectedBetweenDirectional(
+        from, to, destinationBox, visitor
+      );
+    } else {
+      BlockIntersection.forEachBlockIntersectedBetween(
+        from, to, destinationBox,
+        visitor
+      );
+    }
   }
 
   private void simulateWaterAfter(

--- a/src/main/java/de/jpx3/intave/check/movement/physics/simulator/BaseSimulator.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/simulator/BaseSimulator.java
@@ -15,9 +15,11 @@ import de.jpx3.intave.IntaveControl;
 import de.jpx3.intave.adapter.MinecraftVersions;
 import de.jpx3.intave.block.access.VolatileBlockAccess;
 import de.jpx3.intave.block.fluid.Fluids;
+import de.jpx3.intave.block.intersection.BlockIntersection;
 import de.jpx3.intave.block.physics.BlockPhysics;
 import de.jpx3.intave.block.physics.BlockProperties;
 import de.jpx3.intave.block.shape.BlockShape;
+import de.jpx3.intave.block.type.BlockTypeAccess;
 import de.jpx3.intave.check.movement.physics.config.MovementConfiguration;
 import de.jpx3.intave.check.movement.physics.environment.MovementCharacteristics;
 import de.jpx3.intave.check.movement.physics.environment.Pose;
@@ -507,8 +509,8 @@ class BaseSimulator extends Simulator {
       simulateNormalAfter(user, environment, configuration, motion, gravity, slipperiness);
     }
 
-    if (user.meta().protocol().newBlockEntityIntersectionLogic()) {
-      simulateApplyEffectsFromBlocks(user, environment, motion, boundingBox);
+    if (clientData.newBlockEntityIntersectionLogic()) {
+      simulateApplyEffectsFromBlocks(user, environment, motion);
     }
 
     if (clientData.combatUpdate()
@@ -586,34 +588,36 @@ class BaseSimulator extends Simulator {
 
     environment.aquaticUpdateLavaReset();
 
-//    if (!user.meta().protocol().newBlockEntityIntersectionLogic()) {
     double limit = 1.0E-7D;
     int blockPositionStartX = floor(entityBoundingBox.minX + limit);
-      int blockPositionStartY = floor(entityBoundingBox.minY + limit);
-      int blockPositionStartZ = floor(entityBoundingBox.minZ + limit);
-      int blockPositionEndX = floor(entityBoundingBox.maxX - limit);
-      int blockPositionEndY = floor(entityBoundingBox.maxY - limit);
-      int blockPositionEndZ = floor(entityBoundingBox.maxZ - limit);
+    int blockPositionStartY = floor(entityBoundingBox.minY + limit);
+    int blockPositionStartZ = floor(entityBoundingBox.minZ + limit);
+    int blockPositionEndX = floor(entityBoundingBox.maxX - limit);
+    int blockPositionEndY = floor(entityBoundingBox.maxY - limit);
+    int blockPositionEndZ = floor(entityBoundingBox.maxZ - limit);
 
-      Location blockCollisionFrom = new Location(world, positionX, positionY, positionZ);
-      for (int x = blockPositionStartX; x <= blockPositionEndX; x++) {
-        for (int y = blockPositionStartY; y <= blockPositionEndY; y++) {
-          for (int z = blockPositionStartZ; z <= blockPositionEndZ; z++) {
-            Location location = new Location(world, x, y, z);
-            Material material = VolatileBlockAccess.typeAccess(user, world, x, y, z);
-            Motion collisionMotion = BlockPhysics.entityInside(
-              user, material,
-              environment,
-              location, blockCollisionFrom,
-              motion.motionX, motion.motionY, motion.motionZ
-            );
-            if (collisionMotion != null) {
-              motion.setTo(collisionMotion);
-            }
+    Location blockCollisionFrom = new Location(world, positionX, positionY, positionZ);
+    for (int x = blockPositionStartX; x <= blockPositionEndX; x++) {
+      for (int y = blockPositionStartY; y <= blockPositionEndY; y++) {
+        for (int z = blockPositionStartZ; z <= blockPositionEndZ; z++) {
+          Material material = VolatileBlockAccess.typeAccess(user, world, x, y, z);
+          if (clientData.newBlockEntityIntersectionLogic()
+            && material == BlockTypeAccess.BUBBLE_COLUMN) {
+            continue;
+          }
+          Location location = new Location(world, x, y, z);
+          Motion collisionMotion = BlockPhysics.entityInside(
+            user, material,
+            environment,
+            location, blockCollisionFrom,
+            motion.motionX, motion.motionY, motion.motionZ
+          );
+          if (collisionMotion != null) {
+            motion.setTo(collisionMotion);
           }
         }
       }
-//    }
+    }
 
     if (clientData.protocolVersion() >= VER_1_14 && environment.pose() != Pose.FALL_FLYING) {
       int soulSandModifier = Enchantments.resolveSoulSpeedModifier(player);
@@ -626,49 +630,61 @@ class BaseSimulator extends Simulator {
   }
 
   private void simulateApplyEffectsFromBlocks(
-    User user, SimulationEnvironment environment, Motion motion, BoundingBox boundingBox
+    User user, SimulationEnvironment environment, Motion motion
   ) {
     Position from = environment.verifiedLastPosition();
     Position to = environment.position();
-    Motion move = from.motionTo(to);
-
-    SimulationResult simulationResult = environment.simulationResult();
-    if (simulationResult == null || simulationResult.isValid()) {
-      return;
-    }
-    Motion crazyMotion = simulationResult.intermittentResult();
-
+    Motion movement = from.motionTo(to);
     LongSet visitedBlocks = new LongOpenHashSet();
 
-		int i = 16;
-    if (crazyMotion != null && move.lengthSquared() > 0.0) {
-      for (Direction.Axis axis : Direction.axisStepOrder(crazyMotion)) {
-        double motionPartial = crazyMotion.partialMotionIn(axis);
-        if (motionPartial != 0.0) {
-	        Position positionPartial = from.relative(axis.positive(), motionPartial);
-	        i -= checkInsideBlocks(user, environment, from, positionPartial, visitedBlocks, i);
-					from = positionPartial;
+    if (movement.lengthSquared() > 0.0) {
+      for (Direction.Axis axis : Direction.axisStepOrder(movement)) {
+        double movementOnAxis = movement.partialMotionIn(axis);
+        if (movementOnAxis != 0.0) {
+          Position axisDestination = from.relative(axis.positive(), movementOnAxis);
+          applyBubbleColumnsBetween(
+            user, environment, from, axisDestination, motion, visitedBlocks
+          );
+          from = axisDestination;
         }
       }
     } else {
-			i -= checkInsideBlocks(user, environment, from, to, visitedBlocks, i);
+      applyBubbleColumnsBetween(user, environment, from, to, motion, visitedBlocks);
     }
-		if (i <= 0) {
-			checkInsideBlocks(user, environment, from, to, visitedBlocks, 1);
-		}
   }
 
-  private int checkInsideBlocks(
+  private void applyBubbleColumnsBetween(
     User user,
-		SimulationEnvironment environment,
+    SimulationEnvironment environment,
     Position from, Position to,
-    LongSet visitedBlocks,
-    int limit
+    Motion motion,
+    LongSet visitedBlocks
   ) {
-	  BoundingBox box = BoundingBox.fromPosition(user, environment, to).shrink(0.00001f);
-		boolean furtherThanOneBlock = from.distanceSquared(to) > (0.9999900000002526 * 0.9999900000002526);
-
-    return 0;
+    World world = user.player().getWorld();
+    Location movementTarget = to.toLocation(world);
+    BoundingBox destinationBox =
+      BoundingBox.fromPosition(user, environment, to).shrink(1.0E-5F);
+    BlockIntersection.forEachBlockIntersectedBetween(
+      from, to, destinationBox,
+      (blockPosition, ignoredStep) -> {
+        if (!visitedBlocks.add(blockPosition.toLong())) {
+          return true;
+        }
+        Material material = VolatileBlockAccess.typeAccess(user, blockPosition);
+        if (material != BlockTypeAccess.BUBBLE_COLUMN) {
+          return true;
+        }
+        Motion collisionMotion = BlockPhysics.entityInside(
+          user, material, environment,
+          blockPosition.toLocation(world), movementTarget,
+          motion.motionX, motion.motionY, motion.motionZ
+        );
+        if (collisionMotion != null) {
+          motion.setTo(collisionMotion);
+        }
+        return true;
+      }
+    );
   }
 
   private void simulateWaterAfter(

--- a/src/main/java/de/jpx3/intave/user/meta/ProtocolMetadata.java
+++ b/src/main/java/de/jpx3/intave/user/meta/ProtocolMetadata.java
@@ -23,6 +23,7 @@ import java.util.*;
 
 public final class ProtocolMetadata {
   public static int VER_26_1_1 = 775; // 26.1.1
+  public static int VER_1_21_11 = 774; // 1.21.11
   public static int VER_1_21_7 = 772; // 1.21.7
   public static int VER_1_21_5 = 770; // 1.21.5
   public static int VER_1_21_3 = 768; // 1.21.3
@@ -254,6 +255,10 @@ public final class ProtocolMetadata {
 
   public boolean newBlockEntityIntersectionLogic() {
     return protocolVersion >= VER_1_21_7;
+  }
+
+  public boolean directionalBlockEntityIntersectionLogic() {
+    return protocolVersion >= VER_1_21_11;
   }
 
   public boolean oppositeBlockVectorBehavior() {

--- a/src/main/java/de/jpx3/intave/user/meta/ProtocolMetadata.java
+++ b/src/main/java/de/jpx3/intave/user/meta/ProtocolMetadata.java
@@ -23,6 +23,7 @@ import java.util.*;
 
 public final class ProtocolMetadata {
   public static int VER_26_1_1 = 775; // 26.1.1
+  public static int VER_1_21_7 = 772; // 1.21.7
   public static int VER_1_21_5 = 770; // 1.21.5
   public static int VER_1_21_3 = 768; // 1.21.3
   public static int VER_1_21 = 767; // 1.21
@@ -252,7 +253,7 @@ public final class ProtocolMetadata {
 	}
 
   public boolean newBlockEntityIntersectionLogic() {
-    return protocolVersion >= VER_1_21_5;
+    return protocolVersion >= VER_1_21_7;
   }
 
   public boolean oppositeBlockVectorBehavior() {

--- a/src/test/java/de/jpx3/intave/block/intersection/BlockIntersectionTest.java
+++ b/src/test/java/de/jpx3/intave/block/intersection/BlockIntersectionTest.java
@@ -17,9 +17,12 @@ import de.jpx3.intave.share.Position;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BlockIntersectionTest {
   @Test
@@ -48,6 +51,43 @@ class BlockIntersectionTest {
       Set.of(new BlockPosition(0, 1, 0), new BlockPosition(0, 2, 0), new BlockPosition(0, 3, 0)),
       blocks
     );
+  }
+
+  @Test
+  void visitsDirectionalBoxesFromTopWhenMovingDown() {
+    Set<BlockPosition> blocks = new LinkedHashSet<>();
+    BlockIntersection.forEachBlockIntersectedBetweenDirectional(
+      new Position(0.5, 1.0, 0.5),
+      new Position(0.5, 0.7, 0.5),
+      new BoundingBox(0.2, 0.7, 0.2, 0.8, 2.5, 0.8),
+      (blockPosition, ignoredStep) -> {
+        blocks.add(blockPosition);
+        return true;
+      }
+    );
+
+    assertEquals(
+      List.of(
+        new BlockPosition(0, 2, 0),
+        new BlockPosition(0, 1, 0),
+        new BlockPosition(0, 0, 0)
+      ),
+      List.copyOf(blocks)
+    );
+  }
+
+  @Test
+  void distinguishesSweptCandidatesFromPreciseIntersections() {
+    Position from = new Position(0.5, 1.3, 0.5);
+    Position to = new Position(0.5, 0.7, 0.5);
+    BoundingBox destinationBox = new BoundingBox(0.2, 0.7, 0.2, 0.8, 2.5, 0.8);
+
+    assertFalse(BlockIntersection.isPreciseIntersection(
+      from, to, destinationBox, new BlockPosition(0, 3, 0)
+    ));
+    assertTrue(BlockIntersection.isPreciseIntersection(
+      from, to, destinationBox, new BlockPosition(0, 1, 0)
+    ));
   }
 
   private static Set<BlockPosition> visitedBetween(

--- a/src/test/java/de/jpx3/intave/block/intersection/BlockIntersectionTest.java
+++ b/src/test/java/de/jpx3/intave/block/intersection/BlockIntersectionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Intave
+ *
+ * This software is licensed under the PolyForm Perimeter License 1.0.0.
+ * You may use this software for any purpose, except for providing to
+ * others any product that competes with the software.
+ *
+ * A copy of the license is available at:
+ *   https://polyformproject.org/licenses/perimeter/1.0.0/
+ */
+
+package de.jpx3.intave.block.intersection;
+
+import de.jpx3.intave.share.BlockPosition;
+import de.jpx3.intave.share.BoundingBox;
+import de.jpx3.intave.share.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BlockIntersectionTest {
+  @Test
+  void visitsTheDestinationBoxForShortMovement() {
+    Set<BlockPosition> blocks = visitedBetween(
+      new Position(0.5, 0.0, 0.5),
+      new Position(0.5, 0.5, 0.5),
+      new BoundingBox(0.2, 0.5, 0.2, 0.8, 2.3, 0.8)
+    );
+
+    assertEquals(
+      Set.of(new BlockPosition(0, 0, 0), new BlockPosition(0, 1, 0), new BlockPosition(0, 2, 0)),
+      blocks
+    );
+  }
+
+  @Test
+  void includesBlocksCrossedByLongMovementWithoutDuplicates() {
+    Set<BlockPosition> blocks = visitedBetween(
+      new Position(0.5, 0.0, 0.5),
+      new Position(0.5, 2.0, 0.5),
+      new BoundingBox(0.2, 2.0, 0.2, 0.8, 3.8, 0.8)
+    );
+
+    assertEquals(
+      Set.of(new BlockPosition(0, 1, 0), new BlockPosition(0, 2, 0), new BlockPosition(0, 3, 0)),
+      blocks
+    );
+  }
+
+  private static Set<BlockPosition> visitedBetween(
+    Position from, Position to, BoundingBox destinationBox
+  ) {
+    Set<BlockPosition> blocks = new LinkedHashSet<>();
+    BlockIntersection.forEachBlockIntersectedBetween(
+      from, to, destinationBox,
+      (blockPosition, ignoredStep) -> {
+        blocks.add(blockPosition);
+        return true;
+      }
+    );
+    return blocks;
+  }
+}


### PR DESCRIPTION
## Describe your changes

Minecraft 1.21.7 changed when inside-block effects are applied. Bubble column motion is now applied after regular movement and fluid damping.

Intave previously calculated the motion as:

```text
(motionY + bubbleImpulse) * waterDrag
```

The client calculates it as:

```text
motionY * waterDrag + bubbleImpulse
```

This caused the simulated vertical motion to diverge from the client every tick.

For 1.21.7+ clients, bubble columns are now skipped in the existing pre-fluid block-effect loop and processed after water, lava, or normal post-movement physics. Other block effects continue using the existing path.

The new processing checks the movement between the verified previous position and the resulting position. It follows the client's axis order and checks all blocks intersected along the movement path.

The traversal follows Minecraft 1.21.7's `BlockGetter.forEachBlockIntersectedBetween` behavior:

- Short movements check the destination bounding box directly.
- Longer movements trace the swept path.
- Blocks are processed only once.
- Traversal uses the same 16-step limit as the client.

Bubble column surface detection now also matches the client. A column uses the stronger surface impulse only when the block above has both an empty collision shape and an empty fluid state.

The new behavior starts at protocol version `772`. Older clients retain the previous behavior.

Fixes #45

## What was your testing methodology?

Added unit tests covering:

- Destination bounding-box checks for short movements.
- Swept block traversal for movements longer than one block.
- Prevention of duplicate block processing.

The production sources compile successfully. The complete test suite was also executed: 134 of 135 tests pass. The remaining `swimming_toggle` recording failure is pre-existing and reproduces unchanged on `master`.

## What systems are affected by my changes?

- Movement physics simulation for bubble columns on 1.21.7+ clients.
- Inside-block intersection traversal.
- Protocol-version gating for the new block-intersection behavior.

Older clients and non-bubble block effects are not affected.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if other critical systems rely on my changes.
- [x] I read the contribution guidelines and followed them.
- [x] No new class names contain "Utils", "Handler" or "Manager".