### PR TITLE
fix: preserve lava state across simulation branches

### DIFF
--- a/src/main/java/de/jpx3/intave/block/physics/FluidPhysics.java
+++ b/src/main/java/de/jpx3/intave/block/physics/FluidPhysics.java
@@ -18,7 +18,6 @@ import de.jpx3.intave.block.fluid.Fluid;
 import de.jpx3.intave.check.movement.physics.environment.SimulationEnvironment;
 import de.jpx3.intave.share.Motion;
 import de.jpx3.intave.user.User;
-import de.jpx3.intave.user.meta.MovementMetadata;
 import de.jpx3.intave.user.meta.ProtocolMetadata;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -44,10 +43,9 @@ final class FluidPhysics implements BlockPhysic {
   public Motion entityInside(User user, SimulationEnvironment environment, Location location, Location from, double motionX, double motionY, double motionZ) {
     ProtocolMetadata clientData = user.meta().protocol();
     if (clientData.aquaticUpdate()) {
-      MovementMetadata movementData = user.meta().movement();
       Fluid fluid = VolatileBlockAccess.fluidAccess(user, location);
       if (fluid.isOfLava()) {
-        movementData.aquaticUpdateInLava = true;
+        environment.setInLava(true);
       }
     }
     return null;

--- a/src/main/java/de/jpx3/intave/check/movement/physics/environment/ImmutableSimulationEnvironmentCopy.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/environment/ImmutableSimulationEnvironmentCopy.java
@@ -971,7 +971,7 @@ public final class ImmutableSimulationEnvironmentCopy implements SimulationEnvir
 	}
 
 	@Override
-	public void aquaticUpdateLavaReset() {
+	public void setInLava(boolean inLava) {
 		throw immutableCopyException();
 	}
 
@@ -1087,7 +1087,7 @@ public final class ImmutableSimulationEnvironmentCopy implements SimulationEnvir
 		other.setJumpMotion(jumpMotion);
 		other.setInWater(inWater);
 		if (!inLava) {
-			other.aquaticUpdateLavaReset();
+			other.setInLava(false);
 		}
 		if (!inWeb) {
 			other.resetInWeb();

--- a/src/main/java/de/jpx3/intave/check/movement/physics/environment/ImmutableSimulationEnvironmentView.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/environment/ImmutableSimulationEnvironmentView.java
@@ -814,7 +814,7 @@ public final class ImmutableSimulationEnvironmentView implements SimulationEnvir
 	}
 
 	@Override
-	public void aquaticUpdateLavaReset() {
+	public void setInLava(boolean inLava) {
 		throw new UnsupportedOperationException("Cannot modify unmodifiable view");
 	}
 

--- a/src/main/java/de/jpx3/intave/check/movement/physics/environment/MockSimulationEnvironment.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/environment/MockSimulationEnvironment.java
@@ -192,6 +192,7 @@ public final class MockSimulationEnvironment implements SimulationEnvironment {
     this.inWater = inWater;
   }
 
+  @Override
   public void setInLava(boolean inLava) {
     this.inLava = inLava;
   }
@@ -862,11 +863,6 @@ public final class MockSimulationEnvironment implements SimulationEnvironment {
 
   @Override
   public void updateEyesInWater() {
-
-  }
-
-  @Override
-  public void aquaticUpdateLavaReset() {
 
   }
 

--- a/src/main/java/de/jpx3/intave/check/movement/physics/environment/MutableSimulationEnvironmentView.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/environment/MutableSimulationEnvironmentView.java
@@ -990,10 +990,10 @@ public final class MutableSimulationEnvironmentView implements SimulationEnviron
   }
 
   @Override
-  public void aquaticUpdateLavaReset() {
+  public void setInLava(boolean inLava) {
     inLavaOverridden = true;
-    inLava = false;
-    deferredMutations.add(SimulationEnvironment::aquaticUpdateLavaReset);
+    this.inLava = inLava;
+    deferredMutations.add(environment -> environment.setInLava(inLava));
   }
 
   @Override
@@ -1268,8 +1268,8 @@ public final class MutableSimulationEnvironmentView implements SimulationEnviron
     if (inWaterOverridden) {
       other.setInWater(inWater);
     }
-    if (inLavaOverridden && !inLava) {
-      other.aquaticUpdateLavaReset();
+    if (inLavaOverridden) {
+      other.setInLava(inLava);
     }
     if (inWebOverridden && !inWeb) {
       other.resetInWeb();

--- a/src/main/java/de/jpx3/intave/check/movement/physics/environment/SimulationEnvironment.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/environment/SimulationEnvironment.java
@@ -277,6 +277,7 @@ public interface SimulationEnvironment {
   boolean inWater();
   void setInWater(boolean inWater);
   boolean inLava();
+  void setInLava(boolean inLava);
   boolean inWeb();
   void resetInWeb();
   boolean onGround();
@@ -588,8 +589,6 @@ public interface SimulationEnvironment {
   default boolean onGroundWithRiptide() {
     return false;
   }
-
-  void aquaticUpdateLavaReset();
 
   float height();
   void setHeight(float height);

--- a/src/main/java/de/jpx3/intave/check/movement/physics/simulator/BaseSimulator.java
+++ b/src/main/java/de/jpx3/intave/check/movement/physics/simulator/BaseSimulator.java
@@ -584,7 +584,7 @@ class BaseSimulator extends Simulator {
 
     // Block collisions
 
-    environment.aquaticUpdateLavaReset();
+    environment.setInLava(false);
 
 //    if (!user.meta().protocol().newBlockEntityIntersectionLogic()) {
     double limit = 1.0E-7D;

--- a/src/main/java/de/jpx3/intave/user/meta/MovementMetadata.java
+++ b/src/main/java/de/jpx3/intave/user/meta/MovementMetadata.java
@@ -751,8 +751,8 @@ public final class MovementMetadata implements SimulationEnvironment {
 	}
 
   @Override
-  public void aquaticUpdateLavaReset() {
-    aquaticUpdateInLava = false;
+  public void setInLava(boolean inLava) {
+    aquaticUpdateInLava = inLava;
   }
 
   @Override

--- a/src/test/java/de/jpx3/intave/check/movement/physics/environment/MutableSimulationEnvironmentViewTest.java
+++ b/src/test/java/de/jpx3/intave/check/movement/physics/environment/MutableSimulationEnvironmentViewTest.java
@@ -143,6 +143,7 @@ final class MutableSimulationEnvironmentViewTest {
     view.setBoundingBox(box);
     view.setBaseMotion(0.1, 0.2, 0.3);
     view.setInWater(true);
+    view.setInLava(true);
     view.setPushedByEntity(true);
 
     MockSimulationEnvironment target = new MockSimulationEnvironment();
@@ -158,6 +159,7 @@ final class MutableSimulationEnvironmentViewTest {
     assertEquals(90.0F, target.rotationYaw(), 0.0F);
     assertEquals(45.0F, target.rotationPitch(), 0.0F);
     assertFalse(delegate.inWater());
+    assertFalse(delegate.inLava());
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

Lava collisions previously updated `MovementMetadata` directly, while movement searches operate on branched `SimulationEnvironment` instances.

This caused the branch-local lava state to remain `false`, so the simulator applied normal gravity instead of lava physics. For example, a valid lava jump of `+0.04` was simulated as `-0.0392`, causing `HFLYING` and `HCOLLISION` flags.

This change replaces the reset-only lava API with `setInLava(boolean)` and updates `FluidPhysics` to modify the active simulation environment. This keeps the lava state isolated per branch and preserves it when the selected branch is committed.

## What was your testing methodology?

Extended the existing mutable simulation environment test to verify that:

- Setting the lava state does not modify the underlying environment before commit.
- The lava state is transferred to the target environment during commit.

The targeted Gradle test passes successfully.

## What systems are affected by my changes?

- Movement physics simulation
- Lava collision handling
- Branched simulation environments

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests if other critical systems rely on my changes.
- [x] I read the contribution guidelines and followed them.
- [x] No new class names contain "Utils", "Handler" or "Manager".